### PR TITLE
update winbgim.h

### DIFF
--- a/winbgim.h
+++ b/winbgim.h
@@ -299,7 +299,7 @@ void putimage( int left, int top, void *bitmap, int op );
 void printimage(
     const char* title=NULL,	
     double width_inches=7, double border_left_inches=0.75, double border_top_inches=0.75,
-    int left=0, int right=0, int right=INT_MAX, int bottom=INT_MAX,
+    int left=0, int top=0, int right=INT_MAX, int bottom=INT_MAX,
     bool active=true, HWND hwnd=NULL
     );
 void readimagefile(


### PR DESCRIPTION
Correcting a function argument typo in line 302, instead of `int right=0 `it should be `int top=0`
The mistake is already corrected in `graphics.h` but not yet in `winbgim.h`